### PR TITLE
Use target_include_directories() to propagate include dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,19 +32,19 @@ add_library(ViconDataStreamSDK_CPP STATIC
 )
 
 target_link_libraries(ViconDataStreamSDK_CPP
-  PRIVATE 
+  PRIVATE
     Boost::system
     Boost::thread
     Threads::Threads
 )
 
+target_include_directories(ViconDataStreamSDK_CPP PUBLIC
+  Vicon/CrossMarket/DataStream/ViconDataStreamSDK_CPP
+)
+
 target_compile_definitions(ViconDataStreamSDK_CPP PRIVATE "_BUILD_STATIC_LIB")
 
 # Declare an executable
-
-include_directories(
-  Vicon/CrossMarket/DataStream/ViconDataStreamSDK_CPP
-)
 
 add_executable(ViconDataStreamSDK_CPPTest
   Vicon/CrossMarket/DataStream/ViconDataStreamSDK_CPPTest/ViconDataStreamSDK_CPPTest.cpp


### PR DESCRIPTION
This simplifies adding this library, especially using tools like [CPM](https://github.com/cpm-cmake/CPM.cmake) because just linking against your exported target `ViconDataStreamSDK_CPP` also automatically adds the required include directory (`Vicon/CrossMarket/DataStream/ViconDataStreamSDK_CPP`).

Thanks for considering this!

Would appreciate if you could create a new version tag for this once (if) this is merged. :-)