### PR TITLE
Clarify copyright holder in the LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 whoenig
+Copyright (c) 2020 Vicon Motion Systems Ltd, Wolfgang Hönig 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hello @whoenig, thanks a lot for this repo, we were to host somewhere the vicon datastream sdk ourself and add CMake code to build it, but before doing that we discovered your repo, so that was really helpful!

Just to avoid misunderstanding regarding the copyright holder of the code (and to be sure that we comply with the "The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software." clause of the MIT license, I think it make sense to report in the LICENSE file in the root of the repo the same mention of Vicon Motion Systems Ltd present in the files present in the SDK. I also added yourself as copyright holder to account for your modifications, additional files and patches.

What do you think about this change? Thanks again for the repo.

@gianlucamilani @giulioromualdi



